### PR TITLE
Add pseudocode to update ipfs records on edit

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -18,12 +18,37 @@ async function main() {
 
   console.log('IPFS Version:', version.version)
 
+//   fastify.post('/edit', async (request, reply) => {
+//     const file = await ipfsNode.add({
+//       path: request.body.filename,
+//       content: new TextEncoder().encode(JSON.stringify(request.body))
+//     }, {pin: true})
+//     console.log('Added file:', request.body.filename, file.cid.toString())
+    
+//     //publish updated file id under received id
+//     await ipfsNode.name.publish(file.cid, {key: request.body.cid})
+
+//     console.log('Updated file:', request.body.filename, request.body.cid)
+//     return { file: request.body.filename, cid: request.body.cid }
+//   })
+  
   fastify.post('/', async (request, reply) => {
     const filename = `obss_${Crypto.randomUUID()}.txt`
     const file = await ipfsNode.add({
       path: filename,
       content: new TextEncoder().encode(JSON.stringify(request.body))
     }, {pin: true})
+ 
+//     console.log('Added file:', file.path, file.cid.toString())
+//     //publish updated file id under new key id
+//     const keyId = await ipfs.key.gen(filename, {
+//         type: 'rsa',
+//         size: 2048
+//     })
+//     const updatedKey = await ipfsNode.name.publish(file.cid, {key: keyId.id})
+    
+//     console.log('Updated file:', file.path, updatedKey.name)
+//     return { file: file.path, cid: updatedKey.name }
 
     console.log('Added file:', file.path, file.cid.toString())
     return { file: file.path, cid: file.cid.toString() }


### PR DESCRIPTION
Attempt for pseudocode for publishing modified file to ipfs by using ipns. As I understand, key generation is needed because "By default, ipfs.name.publish will use the Peer ID" and we need different address for each file
Based on:
https://github.com/ipfs/js-ipfs/blob/master/docs/core-api/NAME.md#ipfsnamepublishvalue-options
and
https://github.com/ipfs/js-ipfs/blob/master/docs/core-api/KEY.md